### PR TITLE
fix(date-time-utils): remove jiffy and use DateTime

### DIFF
--- a/lib/src/utils/date_time_utils.dart
+++ b/lib/src/utils/date_time_utils.dart
@@ -1,5 +1,4 @@
 import 'package:intl/intl.dart';
-import 'package:jiffy/jiffy.dart';
 
 /// format 1 -> ' ' (space)
 /// format 2 -> -
@@ -157,7 +156,7 @@ class DateTimeUtils {
   }
 
   static DateTime parseIsoDate(String startTime) {
-    return Jiffy.parse(startTime).dateTime;
+    return DateTime.parse(startTime).toLocal();
   }
 
   static DateTime getAbsoluteDate() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -154,14 +154,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
-  jiffy:
-    dependency: "direct main"
-    description:
-      name: jiffy
-      sha256: b09b6aacc0ebe7d178d2fcbabfd73e7d3340594043fe949bb7e0814093b00201
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.3.0"
   js:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ environment:
 dependencies:
   rxdart: ^0.27.7
   intl: ^0.19.0
-  jiffy: ^6.3.0
 
   # Logger
   fa_dart_logger:

--- a/test/utils/date_time_utils_test.dart
+++ b/test/utils/date_time_utils_test.dart
@@ -1,6 +1,5 @@
 import 'package:fa_dart_core/src/utils/date_time_utils.dart';
 import 'package:intl/intl.dart';
-import 'package:jiffy/jiffy.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 
@@ -107,7 +106,7 @@ void main() {
     });
 
     test('should return DateTime from string date', () {
-      final expected = Jiffy.parse(dateTime.toIso8601String()).dateTime;
+      final expected = DateTime.parse(dateTime.toIso8601String());
       final actual = DateTimeUtils.parseIsoDate(dateTime.toIso8601String());
       expect(actual, expected);
     });


### PR DESCRIPTION
We are removing the usage of Jiffy from dart-core