### PR TITLE
fix(format-value): fix formatting in case of international and isCompact false

### DIFF
--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -60,11 +60,11 @@ String formatValue(double value,
   } else {
     if (!isCompact) {
       if (decimalPlaces > 0) {
-        final formatter = NumberFormat(
-            "##,##,###.0${_getHashForDecimalPlaces(decimalPlaces)}");
+        final formatter =
+            NumberFormat("###,###.0${_getHashForDecimalPlaces(decimalPlaces)}");
         return formatter.format(value);
       } else {
-        final formatter = NumberFormat("##,##,###");
+        final formatter = NumberFormat("###,###");
         return formatter.format(value);
       }
     }


### PR DESCRIPTION
In previous commit, formatting in case of international number system was done based on indian number system, 
same is corrected in this sprint.

125629.16, decimalPlaces: 5, locale: 'en_IN' -> 1.25629L
125629.16, decimalPlaces: 2, locale: 'en_IN' -> 1.26L

125629.16, decimalPlaces: 2, locale: 'en_US' -> 125.63K
125629.16, decimalPlaces: 4, locale: 'en_US' -> 125.6292K
125629.16, decimalPlaces: 6, locale: 'en_US' -> 125.629160K


125629.16, decimalPlaces: 6, locale: 'en_US', isCompact: false -> 125,629.16
12562912.1621, decimalPlaces: 6, locale: 'en_US', isCompact: false -> 12,562,912.1621
12562912.1621, decimalPlaces: 0, locale: 'en_US', isCompact: false -> 12,562,912

12562912.1621, decimalPlaces: 0, locale: 'en_IN', isCompact: false -> 1,25,62,912
125912.1621, decimalPlaces: 2, locale: 'en_IN', isCompact: false -> 1,25,912.16